### PR TITLE
htop command cannot resize with env.LINES and env.COLUMNS

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -88,8 +88,6 @@ function Terminal(file, args, opt) {
   cwd = opt.cwd || process.cwd();
   name = opt.name || env.TERM || 'xterm';
   env.TERM = name;
-  env.LINES = rows + '';
-  env.COLUMNS = cols + '';
 
   env = environ(env);
 


### PR DESCRIPTION
I have use pty.js to write a web-based terminal, when I resize windows size on browser, resize event send back over websocket, then invoke pty's resize method. It is correct with vim and top. the htop command hasn't respond to resize event, expect exit and restart the command.

If i comment the env.LINES and env.COLUMNS , everything is right.
